### PR TITLE
Fix bug with project description

### DIFF
--- a/bin/subcommands/project.rb
+++ b/bin/subcommands/project.rb
@@ -18,7 +18,7 @@ class Project < Thor
     printf "Name: %s\n", project.name
     printf "Path w/ Namespace: %s\n", project.path_with_namespace
     printf "Project URL: %s\n", project.project_url
-    printf "Description: %s\n", project.description.empty? ? "N/A" : project.description
+    printf "Description: %s\n", project.description.nil? || project.description.empty? ? "N/A" : project.description
     printf "Default Branch: %s\n", project.default_branch.nil? ? "N/A" : project.default_branch
     printf "Owner: %s <%s>\n", project.owner.name, project.owner.email
     printf "Public?: %s\n", project.public.to_s


### PR DESCRIPTION
NoMethodError raised when there's no project description.

```
gitlab-cli/bin/subcommands/project.rb:23:in `info': undefined method `empty?' for nil:NilClass (NoMethodError)
```

Before call `empty?` to project.description, add `nil?` to check description.empty? is available.
