### PR TITLE
Add an user friendly message for 'config missing'

### DIFF
--- a/lib/gitlab_cli.rb
+++ b/lib/gitlab_cli.rb
@@ -8,8 +8,19 @@ module GitlabCli
   autoload :User,             'gitlab_cli/user'
   autoload :Util,             'gitlab_cli/util'
   autoload :Version,          'gitlab_cli/version'
-
-  config = File.expand_path('~/.gitlab.yml')
+  CONFIG_PATH = '~/.gitlab.yml'
+  config = File.expand_path(CONFIG_PATH)
+  unless File.exist?(config)
+    File.open(File.expand_path(File.dirname(__FILE__) + "/../config.yml.sample", "r") )do |sample|
+      puts "Create a '#{CONFIG_PATH}' as following sample config"
+      puts "=" * 40
+      while (line = sample.gets)
+        puts line
+      end
+      puts "=" * 40
+    end
+    exit(-1)
+  end
   GitlabCli::Config.load(config)
 
   # 3rd Party Gems


### PR DESCRIPTION
A very simple help message to show a sample config from code repository
